### PR TITLE
bump image version to revision-10.0.0-r3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM gcr.io/stacksmith-images/ubuntu:14.04-r9
 MAINTAINER Bitnami <containers@bitnami.com>
 
-ENV BITNAMI_IMAGE_VERSION=10.0.0-r2 \
+ENV BITNAMI_IMAGE_VERSION=10.0.0-r3 \
     BITNAMI_APP_NAME=wildfly \
     BITNAMI_APP_USER=wildfly
 

--- a/README.md
+++ b/README.md
@@ -338,6 +338,10 @@ bats test.sh
 
 # Notable Changes
 
+## 10.0.0-r3
+
+- `WILDFLY_USER` parameter has been renamed to `WILDFLY_USERNAME`.
+
 ## 10.0.0-r0
 
 - All volumes have been merged at `/bitnami/tomcat`. Now you only need to mount a single volume at `/bitnami/tomcat` for persistence.


### PR DESCRIPTION
- `WILDFLY_USER` parameter has been renamed to `WILDFLY_USERNAME`.