### PR TITLE
Delete Docker Hub badge and include new section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 [![CircleCI](https://circleci.com/gh/bitnami/bitnami-docker-wildfly/tree/master.svg?style=shield)](https://circleci.com/gh/bitnami/bitnami-docker-wildfly/tree/master)
-[![Docker Hub Automated Build](http://container.checkforupdates.com/badges/bitnami/wildfly)](https://hub.docker.com/r/bitnami/wildfly/)
 [![Slack](http://slack.oss.bitnami.com/badge.svg)](http://slack.oss.bitnami.com)
 
 # What is Wildfly?
@@ -24,6 +23,14 @@ services:
       - '8080:8080'
       - '9990:9990'
 ```
+
+# Why use Bitnami Images ?
+
+* Bitnami closely tracks upstream source changes and promptly publishes new versions of this image using our automated systems.
+* With Bitnami images the latest bug fixes and features are available as soon as possible.
+* Bitnami containers, virtual machines and cloud images use the same components and configuration approach - making it easy to switch between formats based on your project needs.
+* Bitnami images are built on CircleCI and automatically pushed to the Docker Hub.
+* All our images are based on minideb a minimalist Debian based container image which gives you a small base container image and the familiarity of a leading linux distribution.
 
 # Supported tags and respective `Dockerfile` links
 


### PR DESCRIPTION
This change will delete the Docker Hub Automated build badge and include a new section, "Why use Bitnami Images ?"